### PR TITLE
Reset feeling when initializing the level

### DIFF
--- a/src/dflevel.pas
+++ b/src/dflevel.pas
@@ -502,6 +502,7 @@ begin
   FFlags := [];
   FEmpty := False;
   FHooks := [];
+  FFeeling := '';
 
   FFloorCell  := LuaSystem.Defines[LuaSystem.Get(['generator','styles',FStyle,'floor'])];
   FFloorStyle := LuaSystem.Get(['generator','styles',FStyle,'style'],0);


### PR DESCRIPTION
Ensure the feeling is blank when starting a new level, rather than leave the previous feeling unchanged. This also fixes an issue where the last game's feelings are not overwritten when starting the next game.

This addresses bug https://forum.chaosforge.org/index.php/topic,8899.0.html

Case investigated
---
Proceed to Arena
Abandon Run
Start a new run
Level feeling is You enter Hell's Arena
You can again Abandon Run and start a new run and the level feeling will remain.

After patch
---
Proceed to Arena
Abandon Run
Start a new run
No level feeling is shown

Other use cases tested:
* Start a new game. No feeling. Save and reload. No feeling
* Proceed to L2. Feeling: You sense a passage to a place beyond. Save and reload. Feeling: You sense a passage to a place beyond.
* Proceed to Hell's Arena. Feeling: You enter Hell's Arena. Save and reload. Feeling: You sense a passage to a place beyond.