### PR TITLE
#106: Apostle is buffed to 500hp and teleports on hit.

### DIFF
--- a/bin/data/drl/beings.lua
+++ b/bin/data/drl/beings.lua
@@ -1567,7 +1567,7 @@ function drl.register_beings()
 		sprite       = SPRITE_APOSTLE,
 		sframes      = 2,
 		sflags       = { SF_LARGE },
-		hp           = 255,
+		hp           = 500,
 		armor        = 30,
 		vision       = 2,
 		attackchance = 60,
@@ -1627,6 +1627,13 @@ function drl.register_beings()
 				self:play_sound("act")
 			end
 		end,
+
+		OnAttacked = function (self)
+			self:play_sound("phasing")
+			level:explosion( self.position, 1, 50, 0, 0, LIGHTBLUE )
+			self:phase()
+			level:explosion( self.position, 1, 50, 0, 0, LIGHTBLUE )
+    	end,
 
 		OnDie = function (self)
 			player:add_medal("dragonslayer2")

--- a/bin/version.txt
+++ b/bin/version.txt
@@ -1,5 +1,6 @@
 0.9.9.9 BETA 7
 [fix] -- GH#241: clearing of level feeling on death/restart [brisbang] 
+[mod] -- GH#106: apostle is buffed and teleports on hit [brisbang]
 
 0.9.9.9 BETA 6d
 [mod] -- RCMOD : gun kata move firetime bonus is now 50%


### PR DESCRIPTION
Unit testing passes:
* Apostle phases on hit

Notes:
* playability may not be suitable. Teleportation to outside viewable area means that although the player is likely berserked, the boss is difficult to track (without sound) and random searching enables the boss to heal to full health.

Suggestion: Lower the phase distance on hit.