### PR TITLE
Include all of the binary files for VSCode

### DIFF
--- a/drl.code-workspace
+++ b/drl.code-workspace
@@ -9,13 +9,13 @@
 			"name": "modules"
 		},
 		{
-			"path": "bin\\data",
-			"name": "data"
+			"path": "bin",
+			"name": "bin"
 		},
 		{
 			"path": "..\\fpcvalkyrie\\src",
 			"name": "fpcValkyrie"
-		}
+		},
 	],
 	"settings": {}
 }


### PR DESCRIPTION
Previously only a subfolder of bin was included. Now the entire bin folder is included to enable searching of (e.g.) godmode.lua