### PR TITLE
#232: Increasing the trigger rectangle to cover the wall edges.

### DIFF
--- a/bin/data/drl/levels/abyssal.lua
+++ b/bin/data/drl/levels/abyssal.lua
@@ -97,7 +97,7 @@ register_level "abyssal_plains"
 		local time = core.game_time()
 		local res = level.status
 		if res > 1 then return end
-		if res == 0 and player.x > 29 and player.x < 49 and player.y > 8 and player.y < 13 then
+		if res == 0 and player.x > 29 and player.x < 49 and player.y > 7 and player.y < 14 then
 			ui.msg("Suddenly you're trapped in!")
 			level:play_sound( "door.close", player.position )
 			generator.transmute( "gwall", "floor" )


### PR DESCRIPTION
Alternatively, this might be a legit strategy, to activate the trap from the center, in which case the feature should be ignored.

Unit tests:
* Approach top left triggers
* Approach bottom left triggers
* Approach top right triggers
* Approach bottom right triggers
Wall sliding no longer works.