### PR TITLE
Feature/nuke disables traps

### DIFF
--- a/bin/data/drl/levels/abyssal.lua
+++ b/bin/data/drl/levels/abyssal.lua
@@ -89,6 +89,15 @@ register_level "abyssal_plains"
 		level:transmute( "gwall", "floor" )
 	end,
 
+	OnNuked = function()
+		for b in level:beings() do
+			if not b:is_player() then return end
+		end
+		level.data.kill_all = true
+		--Skip the wall trap sequence if required
+		level.status = 2
+	end,
+
 	OnEnter = function ()
 		level.status = 0
 	end,

--- a/bin/data/drl/levels/containment.lua
+++ b/bin/data/drl/levels/containment.lua
@@ -71,9 +71,14 @@ PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
 		if level.status ~= 3 then return end
 		ui.msg("I guess I prefered the Wall.")
 		level.status = 4
-		if CHALLENGE == "challenge_aohu" then
-			player:add_medal("everysoldier")
+	end,
+
+	OnNuked = function ()
+		for b in level:beings() do
+			if not b:is_player() then return end
 		end
+		--Skip the wall trap sequence if required
+		level.status = 4
 	end,
 
 	OnTick = function ()
@@ -120,6 +125,9 @@ PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
 			ui.msg("Luckily it's not as bad as tricks and traps...")
 			player:add_history("He emerged from the Containment Area victorious!")
 			player:add_badge("wall1")
+			if CHALLENGE == "challenge_aohu" then
+				player:add_medal("everysoldier")
+			end
 			if core.is_challenge("challenge_aomr") or core.is_challenge("challenge_aob") or core.is_challenge("challenge_aosh") then
 				player:add_badge("wall2")
 			end

--- a/bin/godmode.lua
+++ b/bin/godmode.lua
@@ -97,6 +97,7 @@ Keytable["F8"]        = function()
 	player.inv:add( 'utrigun')
 	player.inv:add( 'urailgun')
 	player.inv:add( 'udragon')
+	player.inv:add( 'nuke' )
 	for i = 1,5 do
 		player.inv:add( 'cell', { ammo = 50 } )
 	end

--- a/bin/version.txt
+++ b/bin/version.txt
@@ -1,6 +1,6 @@
 0.9.9.9 BETA 7
 [fix] -- GH#241: clearing of level feeling on death/restart [brisbang]
-[fix] -- GH#113: thermonuclear explosions on Abyssal Plains/Containment area count as level clearances [brisbang]
+[fix] -- GH#113: thermonuclear explosions on Abyssal Plains/Containment area count also clear the traps [brisbang]
 [fix] -- GH#232: fixed Abyssal Plains trap not always triggering [brisbang]
 [fix] -- GH#100: completion of Ao666 reports 666 levels completed [brisbang]
 

--- a/bin/version.txt
+++ b/bin/version.txt
@@ -1,5 +1,6 @@
 0.9.9.9 BETA 7
 [fix] -- GH#241: clearing of level feeling on death/restart [brisbang]
+[fix] -- GH#113: thermonuclear explosions on Abyssal Plains/Containment area count as level clearances [brisbang]
 [fix] -- GH#232: fixed Abyssal Plains trap not always triggering [brisbang]
 [fix] -- GH#100: completion of Ao666 reports 666 levels completed [brisbang]
 


### PR DESCRIPTION
For Abyssal Plains and Containment Area, a nuke execution now sets the level state to finalise the trap sequence. Before this occurs a final check that all beings are dead takes place, just in case there are survivors (somehow). The code is not duplicated, so the normal finishing messages do not display. I wasn't able to chain the event triggers together to have a hook call a shared function, or have a hook call another hooked function. That would improve the code quality.

NB: godmode now contains a nuke as part of the kit. If this is undesirable then happy to have it removed, however it seemed to go with the ultra-powerful theme.

Unit tests:
* Containment area: Setting off a nuke no longer invokes the trap and rewards the player with the clearance result
* Containment area: Clearing the level normally via the trap rewards the player with the clearance result
* Abyssal plains: Setting off a nuke no longer invokes the trap rewards the player with the clearance result
* Abyssal plains: Clearing the level normally via the trap rewards the player with the clearance result