### PR TITLE
#256 - This alters the order of events so that a quick-equip places t…

### DIFF
--- a/src/dfbeing.pas
+++ b/src/dfbeing.pas
@@ -1012,7 +1012,8 @@ var isOnGround : Boolean;
     isPack     : Boolean;
     isEquip    : Boolean;
     isPrepared : Boolean;
-    isUsed     : Boolean;
+    isUse      : Boolean;
+    isUsedUp   : Boolean;
     isFailed   : Boolean;
     iSlot      : TEqSlot;
     iUID       : TUID;
@@ -1027,6 +1028,7 @@ begin
   isLever := aItem.isLever;
   isPack  := aItem.isPack;
   isEquip := aItem.isWearable;
+  isUse   := not isEquip;
   iUID    := aItem.uid;
   if isOnGround then
     begin
@@ -1050,37 +1052,39 @@ begin
 			end
 		  else
 			begin
-  			  isEquip := False;
-			  isFailed := True;
 			  Emote( 'You must unequip first!', '', [ aItem.GetName(false) ] );
+			  isFailed := True;
 			end;
 		end;
 	end
   else
      Emote( 'You use %s.', 'uses %s.', [ aItem.GetName(false) ] );
+  if isFailed then 
+    Exit( False );
 
-  if not isFailed then
-    if isEquip
-      then aItem.PlaySound( 'pickup', FPosition )
-      else aItem.PlaySound( 'use', FPosition );
+  if isEquip then
+  begin
+    aItem.PlaySound( 'pickup', FPosition );
+    Inv.setSlot( iSlot, aItem );
+  end;
+  if isUse then
+    aItem.PlaySound( 'use', FPosition );
   if isEquip or isPack then
     begin
       CallHook( Hook_OnPickUpItem, [aItem] );
-	  aItem.CallHook( Hook_OnPickup,[Self] )
+      aItem.CallHook( Hook_OnPickup,[Self] )
     end;
-  if isEquip then
-    Inv.setSlot( iSlot, aItem )
-  else
-    isUsed := aItem.CallHookCheck( Hook_OnUse,[Self] );
-	 
-  if ((UIDs.Get( iUID ) <> nil) and isUsed and (isLever or isPack)) then FreeAndNil( aItem );
+  if isUse then
+  begin
+    isUsedUp := aItem.CallHookCheck( Hook_OnUse,[Self] );
+    if isUsedUp and ((UIDs.Get( iUID ) <> nil)  and (isLever or isPack)) then FreeAndNil( aItem );
+  end;
   
-  if not isFailed then
-    if (BF_INSTAUSE in FFlags) and (not isEquip) then
-      Dec(FSpeedCount,100)
-    else
-      Dec(FSpeedCount,1000);
-  Exit( not isFailed );
+  if (BF_INSTAUSE in FFlags) and isUse then
+    Dec(FSpeedCount,100)
+  else
+    Dec(FSpeedCount,1000);
+  Exit( True );
 end;
 
 function TBeing.ActionUnLoad ( aItem : TItem; aDisassembleID : AnsiString = '' ) : Boolean;


### PR DESCRIPTION
#256 - This alters the order of events so that a quick-equip places the item into the inventory before triggering OnPickup. This fixes an issue where a chainsaw (for example) is not brought into active wield on a quick pickup.
Other minor changes are:
* A failure to equip exits sooner (no following tasks should run normally anyway)
* IsUsed is renamed to be IsUsedUp
* IsUse now reflects the non-equip path with better readability
* The logic of the various paths is more explicit than implicit (i.e. preferring isUse rather than not isEquip)
* A further improvement would be to use enums to track what type of event is occurring

Unit testing:
* Quick pickup from the ground
* Quick pickup when one weapon slot is available
* Quick pickup when both weapon slots are full fails as expected
* Quick pickup an invalid object (berserk pack) fails as expected
* Quick pickup of the chainsaw no longer brings up an error, and switches to the chainsaw
* Using a lever is fine
* Quick using a phase device works fine
* Quick using a bulk mod pack works fine