### PR TITLE
Captains now get 40 additional ammo, whilst Nightmare Archviles have …

### DIFF
--- a/bin/data/drl/beings.lua
+++ b/bin/data/drl/beings.lua
@@ -79,7 +79,7 @@ function drl.register_beings()
 
 		OnCreate = function (self)
 			self.eq.weapon = "chaingun"
-			self.inv:add( "ammo", { ammo = 100 } )
+			self.inv:add( "ammo", { ammo = 40 } )
 		end
 	}
 
@@ -1137,7 +1137,7 @@ function drl.register_beings()
 		weapon = {
 			damage     = "20d1",
 			damagetype = DAMAGE_PLASMA,
-			radius     = 1,
+			radius     = 2,
 			flags      = { IF_AUTOHIT },
 			missile = {
 				sound_id   = "arch",


### PR DESCRIPTION
Captains get 40 ammo in place of 100. Elite Captains are unchanged.
Nightmare Archviles get a radius 2 explosion in place of 1
As suggested by OmegaTyrant: https://forum.chaosforge.org/index.php/topic,8853.msg71184.html