### PR TITLE
#280 house of pain

### DIFF
--- a/bin/data/drl/levels/house.lua
+++ b/bin/data/drl/levels/house.lua
@@ -35,7 +35,7 @@ register_level "house_of_pain"
 			['#'] = {"iwall", flags = {LFPERMANENT} },
 			['$'] = {"gwall", flags = {LFPERMANENT} },
 			['Z'] = {"rwall", flags = {LFPERMANENT} },
-			['+'] = "door",
+			['+'] = "ldoor",
 			['>'] = "stairs",
 			['-'] = "water",
 			['~'] = "acid",
@@ -79,7 +79,7 @@ register_level "house_of_pain"
 ]=]
 		generator.place_tile( translation, map, 1, 1 )
 		generator.set_permanence( area.FULL )
-		generator.set_permanence( area.FULL, true, "door" )
+		generator.set_permanence( area.FULL, true, "ldoor" )
 
 		level:player(14,10)
 	end,
@@ -90,7 +90,6 @@ register_level "house_of_pain"
 			if not level.data.is_staff then
 				ui.msg("The doors unlock.")
 				level:transmute("ldoor","door")
-				generator.set_permanence(area.FULL, true, "door")
 			end
 			if res == 0 then
 				level.status = 1
@@ -141,7 +140,6 @@ register_level "house_of_pain"
 			if not level.data.is_staff then
 				level:play_sound( "door.close", player.position )
 				level:transmute({"door","odoor"},"ldoor")
-				generator.set_permanence(area.FULL, true, "ldoor")
 				ui.msg("The doors shut violently!")
 			end
 		end

--- a/bin/data/drl/main.lua
+++ b/bin/data/drl/main.lua
@@ -580,8 +580,8 @@ function drl.OnCreateEpisode()
 		{"the_wall","containment_area"}, -- 11/3
 		{"city_of_skulls","abyssal_plains"}, -- 12/4
 		{"halls_of_carnage","spiders_lair"}, -- 14/6
-		{"the_vaults","house_of_pain"}, -- 17/3
-		{"unholy_cathedral"}, -- 19/1
+		{"the_vaults","house_of_pain"}, -- 17/1
+		{"unholy_cathedral"}, -- 19/3
 		{"the_mortuary","limbo"},-- 20/4
 		{"the_lava_pits","mt_erebus"},-- 22/6
 	}


### PR DESCRIPTION
Level begins with doors locked. As monsters are killed doors unlock, and relock on new spawns.

Unit testing:

Confirmed door is locked on level start.
Confirmed door is unbreakable
Confirmed door unlocks when 1st room cleared
Confirmed that open doors remain unbreakable
Confirmed door relocks on 2nd room
Confirmed 2nd opening doors are unbreakable
Confirmed 2nd closing doors are unbreakable
Confirmed 2nd room clearance opens 3rd room
Confirmed 3rd room opening doors are unbreakable
Confirmed 3rd room opening doors are relocked
Confirmed 3rd room doors open when cleared
Confirmed starting room doors lock on entry
Confirmed starting room doors are unbreakable