### PR TITLE
#283 Feature/level empty flag reset

### DIFF
--- a/src/dflevel.pas
+++ b/src/dflevel.pas
@@ -1438,6 +1438,7 @@ begin
       else iBeing := TBeing.Create( State.ToId(2) );
     Level.DropBeing( iBeing, State.ToCoord(3) );
     State.Push( iBeing );
+    Level.FEmpty := False;
   except
     on EPlacementException do
     begin


### PR DESCRIPTION
When there is a scripted summon, it will reset the level's cleared status.

Unit testing
* In house of pain, when the first room is cleared, the level is cleared
* When moving into the next room, activating the next group of monsters, the level indicator becomes red once more.
* When playing in nightmare mode, the level is never shown to be unsafe.