### PR TITLE
#286 Feature/minor typo in vaults

### DIFF
--- a/bin/data/drl/levels/vaults.lua
+++ b/bin/data/drl/levels/vaults.lua
@@ -156,7 +156,7 @@ register_level "the_vaults"
 		local result = level.status
 		player:add_badge("vaults1")
 		if result == 0 then
-			ui.msg("All these treasure left behind...")
+			ui.msg("All these treasures left behind...")
 			player:add_history("He came, he saw, but he left.")
 		elseif result == 1 or result == 3 then
 			ui.msg("At least I got something!")


### PR DESCRIPTION
Testing:
Entered the vaults and left. The message appeared but was immediately overwritten by the next level's message and so only viewable in message history.

Maybe exit messages don't really appear?